### PR TITLE
Add studio package model to unblock module installation

### DIFF
--- a/models/__init__.py
+++ b/models/__init__.py
@@ -21,3 +21,4 @@ from . import royalty_payment
 from . import publ_split
 from . import sync_license
 from . import dist_partner
+from . import studio_package

--- a/models/studio_package.py
+++ b/models/studio_package.py
@@ -1,0 +1,67 @@
+# -*- coding: utf-8 -*-
+
+from odoo import api, fields, models, _
+from odoo.exceptions import ValidationError
+
+
+class StudioPackage(models.Model):
+    _name = 'studio.package'
+    _description = 'Studio Service Package'
+    _inherit = ['mail.thread', 'mail.activity.mixin']
+    _order = 'sequence, name'
+
+    name = fields.Char(string='Package Name', required=True, tracking=True)
+    sequence = fields.Integer(default=10)
+    active = fields.Boolean(default=True, tracking=True)
+
+    description = fields.Text(string='Description')
+    notes = fields.Text(string='Internal Notes')
+
+    room_id = fields.Many2one(
+        'studio.room',
+        string='Suggested Room',
+        help='Default studio room typically used for this package.',
+        tracking=True,
+    )
+    duration_hours = fields.Float(
+        string='Included Hours',
+        default=4.0,
+        help='Number of studio hours included in the package.',
+    )
+    engineer_included = fields.Boolean(
+        string='Engineer Included',
+        default=True,
+        help='Whether an engineer is included in the package price.',
+    )
+    equipment_ids = fields.Many2many(
+        'studio.equipment',
+        string='Included Equipment',
+        help='Equipment that is bundled with the package.',
+    )
+
+    currency_id = fields.Many2one(
+        'res.currency',
+        string='Currency',
+        required=True,
+        default=lambda self: self.env.company.currency_id,
+    )
+    package_rate = fields.Monetary(
+        string='Package Rate',
+        required=True,
+        tracking=True,
+        help='Total price of the package including included services.',
+    )
+
+    additional_cost_notes = fields.Text(
+        string='Additional Cost Notes',
+        help='Describe any optional add-ons or exclusions for this package.',
+    )
+
+    @api.constrains('package_rate', 'duration_hours')
+    def _check_positive_values(self):
+        for package in self:
+            if package.package_rate < 0:
+                raise ValidationError(_('The package rate cannot be negative.'))
+            if package.duration_hours <= 0:
+                raise ValidationError(_('The included hours must be greater than zero.'))
+

--- a/security/ir.model.access.csv
+++ b/security/ir.model.access.csv
@@ -24,6 +24,7 @@ access_publ_registration_label_exec,publ.registration label exec,model_publ_regi
 access_sync_license_label_exec,sync.license label exec,model_sync_license,group_label_exec,1,1,1,1
 access_dist_partner_label_exec,dist.partner label exec,model_dist_partner,group_label_exec,1,1,1,1
 access_royalty_rule_label_exec,royalty.rule label exec,model_royalty_rule,group_label_exec,1,1,1,1
+access_studio_package_label_exec,studio.package label exec,model_studio_package,group_label_exec,1,1,1,1
 
 # A&R Manager
 access_partner_anr_manager,res.partner anr manager,base.model_res_partner,group_anr_manager,1,1,1,0
@@ -52,6 +53,7 @@ access_studio_room_manager,studio.room studio manager,model_studio_room,group_st
 access_studio_equipment_manager,studio.equipment studio manager,model_studio_equipment,group_studio_manager,1,1,1,0
 access_studio_booking_manager,studio.booking studio manager,model_studio_booking,group_studio_manager,1,1,1,0
 access_studio_session_manager,studio.session studio manager,model_studio_session,group_studio_manager,1,1,1,0
+access_studio_package_manager,studio.package studio manager,model_studio_package,group_studio_manager,1,1,1,0
 
 # Studio Staff
 access_partner_studio_staff,res.partner studio staff,base.model_res_partner,group_studio_staff,1,0,0,0
@@ -59,6 +61,7 @@ access_studio_room_staff,studio.room studio staff,model_studio_room,group_studio
 access_studio_equipment_staff,studio.equipment studio staff,model_studio_equipment,group_studio_staff,1,0,0,0
 access_studio_booking_staff,studio.booking studio staff,model_studio_booking,group_studio_staff,1,1,1,0
 access_studio_session_staff,studio.session studio staff,model_studio_session,group_studio_staff,1,1,1,0
+access_studio_package_staff,studio.package studio staff,model_studio_package,group_studio_staff,1,0,0,0
 
 # Publishing Manager
 access_partner_publishing_manager,res.partner publishing manager,base.model_res_partner,group_publishing_manager,1,1,1,0


### PR DESCRIPTION
## Summary
- add a studio.package model to satisfy the booking package reference
- expose the new model in the module init so it loads correctly
- grant Label Executive, Studio Manager, and Studio Staff access to the package records

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_b_68d34333f8cc83228e9861de990e4617