### PR TITLE
Add studio booking link to account moves

### DIFF
--- a/models/studio_booking.py
+++ b/models/studio_booking.py
@@ -334,3 +334,14 @@ class StudioBooking(models.Model):
             date_deadline=self.start_datetime.date() - timedelta(days=1),
             summary='Send 24h booking reminder',
         )
+
+
+class AccountMove(models.Model):
+    _inherit = 'account.move'
+
+    studio_booking_id = fields.Many2one(
+        'studio.booking',
+        string='Studio Booking',
+        ondelete='set null',
+        help='Booking that generated this invoice.'
+    )


### PR DESCRIPTION
## Summary
- add an `account.move` extension so invoices can link back to the originating studio booking

## Testing
- python -m compileall models/studio_booking.py

------
https://chatgpt.com/codex/tasks/task_b_68d34723b54883228b050c0c4fa53cf0