### PR TITLE
Fix missing ValidationError import in settings

### DIFF
--- a/models/res_config_settings.py
+++ b/models/res_config_settings.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from odoo import models, fields, api, _
+from odoo.exceptions import ValidationError
 
 
 class ResConfigSettings(models.TransientModel):


### PR DESCRIPTION
## Summary
- import `ValidationError` in the configuration settings model so its constraints can execute

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_b_68d34fbe56948322abd5f910f326ff45